### PR TITLE
Handle null and int parse errors in frame function arg values

### DIFF
--- a/common/util.py
+++ b/common/util.py
@@ -92,16 +92,15 @@ def get_frame_arguments(frame: SBFrame) -> str:
     args = []
     for var in variables:
         # get and format argument value
-        if var.GetValue() is None:
+        value = "???"
+        var_value = var.GetValue()
+        if var_value is None:
             value = "null"
-        elif var.GetValue():
+        elif var_value:
             try:
                 value = f"{int(var.GetValue(), 0):#x}"
             except ValueError:
-                value = "???"
-        else:
-            # Arg name identified but value lookup failed.
-            value = "???"
+                pass
         args.append(
             f"{TERM_COLOURS.YELLOW.value}{var.GetName()}{TERM_COLOURS.ENDC.value}={value}"
         )


### PR DESCRIPTION
nullptr args now handle / display correctly

```
__libc_start_main_impl(main=0x555555555149 argc=0x1 argv=0x7fffffffe038 init=null fini=null rtld_fini=null stack_end=0x7fffffffe028)
```

Also added extra checks around the arg `value.GetValue()` call when casting to an int to safely handle ValueError exceptions