### PR TITLE
Add support for debugging Apple binaries by aliasing arm64e to Aarch64

### DIFF
--- a/arch/__init__.py
+++ b/arch/__init__.py
@@ -11,14 +11,16 @@ from common.constants import MSG_TYPE
 from common.util import extract_arch_from_triple, print_message
 
 # macOS devices running arm chips identify as arm64.
-# aarch64 and arm64 backends have been merged, so alias arm64 to aarch64
+# aarch64 and arm64 backends have been merged, so alias arm64 to aarch64.
+# There's also arm64e architecture, which is basically ARMv8.3
+# but includes pointer authentication and for now is Apple-specific.
 supported_arch = {
     "arm": Arm,
     "x86_64": X86_64,
     "aarch64": Aarch64,
     "arm64": Aarch64,
+    "arm64e": Aarch64,
 }
-
 
 def get_arch(target: SBTarget) -> Type[BaseArch]:
     """Get the architecture of a given target"""


### PR DESCRIPTION
Apple binaries use the arm64e ABI and not arm64, so running llef on them just errors out.
From what I gathered the only difference is pointer authentication so there shouldn't be anything specific llef should add and I tested this patch myself and everything seems to work.