### PR TITLE
Fixed issue with code view when running context command.

### DIFF
--- a/common/context_handler.py
+++ b/common/context_handler.py
@@ -223,8 +223,9 @@ class ContextHandler:
         if self.frame.disassembly:
             instructions = self.frame.disassembly.split("\n")
 
+            current_pc = hex(self.frame.GetPC())
             for i, item in enumerate(instructions):
-                if "\x1b[33m-> \x1b[0m" in item:
+                if current_pc in item:
                     print(instructions[0])
                     if i > 3:
                         print_instruction(instructions[i - 3], TERM_COLOURS.GREY)


### PR DESCRIPTION
Sorry I missed this in the initial pr. Previously, using the context command would cause llef to render the disassembly the current instruction being the start of the frame, rather than at a frame offset. Thanks to @jthorpe6 for spotting this.

When reaching an instruction by stepping (si)

![image](https://github.com/foundryzero/llef/assets/110530254/f5a867ab-522c-4c0f-9873-e8a879da20cb)

When running context, on that instruction

![image](https://github.com/foundryzero/llef/assets/110530254/d88b3b77-baf9-4bfc-baf3-54f8eb4f174f)

This is because the `display_code` function looked for the presence of an arrow marker to denote the current instruction, however this is not present in the `SBExecutionContext` that is passed via the context command. To fix this, the patch identifies the current instruction by comparing the disassembly addresses to the current PC