### PR TITLE
Add experimental force_arch setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,17 @@ Settings are stored in a file `.llef` located in your home directory formatted a
 
 ##### Available Settings
 
-| Setting           | Type    | Description                          |
-|-------------------|---------|--------------------------------------|
-| color_output      | Boolean | Enable/disable color terminal output |
-| register_coloring | Boolean | Enable/disable register coloring     |
-| show_legend       | Boolean | Enable/disable legend output         |
-| show_registers    | Boolean | Enable/disable registers output      |
-| show_stack        | Boolean | Enable/disable stack output          |
-| show_code         | Boolean | Enable/disable code output           |
-| show_threads      | Boolean | Enable/disable threads output        |
-| show_trace        | Boolean | Enable/disable trace output          |
+| Setting           | Type    | Description                                        |
+|-------------------|---------|----------------------------------------------------|
+| color_output      | Boolean | Enable/disable color terminal output               |
+| register_coloring | Boolean | Enable/disable register coloring                   |
+| show_legend       | Boolean | Enable/disable legend output                       |
+| show_registers    | Boolean | Enable/disable registers output                    |
+| show_stack        | Boolean | Enable/disable stack output                        |
+| show_code         | Boolean | Enable/disable code output                         |
+| show_threads      | Boolean | Enable/disable threads output                      |
+| show_trace        | Boolean | Enable/disable trace output                        |
+| force_arch        | String  | Force register display architecture (experimental) |
 
 #### Context
 

--- a/arch/__init__.py
+++ b/arch/__init__.py
@@ -24,9 +24,15 @@ supported_arch = {
     "arm64e": Aarch64,
 }
 
+
 def get_arch(target: SBTarget) -> Type[BaseArch]:
     """Get the architecture of a given target"""
     arch = extract_arch_from_triple(target.triple)
+    return get_arch_from_str(arch)
+
+
+def get_arch_from_str(arch: str) -> Type[BaseArch]:
+    """Get the architecture class from string"""
     if arch in supported_arch:
         return supported_arch[arch]
 

--- a/arch/i386.py
+++ b/arch/i386.py
@@ -46,5 +46,6 @@ class I386(BaseArch):
     }
 
     flag_registers = [
-        FlagRegister("eflags", _eflags_register_bit_masks)
+        FlagRegister("eflags", _eflags_register_bit_masks),
+        FlagRegister("rflags", _eflags_register_bit_masks)
     ]

--- a/common/context_handler.py
+++ b/common/context_handler.py
@@ -12,7 +12,7 @@ from lldb import (
     SBValue,
 )
 
-from arch import get_arch
+from arch import get_arch, get_arch_from_str
 from arch.base_arch import BaseArch, FlagRegister
 from common.constants import GLYPHS, TERM_COLORS
 from common.settings import LLEFSettings
@@ -202,9 +202,9 @@ class ContextHandler:
         """Print the registers display section"""
 
         print_line_with_string("registers")
-        for reg in get_registers(self.frame, self.arch().gpr_key):
-            if reg.GetName() in self.arch().gpr_registers:
-                self.print_register(reg)
+        for reg in self.arch().gpr_registers:
+            if self.frame.register[reg] is not None:
+                self.print_register(self.frame.register[reg])
         for flag_register in self.arch.flag_registers:
             if self.frame.register[flag_register.name] is not None:
                 self.print_flags_register(flag_register)
@@ -312,7 +312,11 @@ class ContextHandler:
         self.process = exe_ctx.GetProcess()
         self.target = exe_ctx.GetTarget()
         self.thread = exe_ctx.GetThread()
-        self.arch = get_arch(self.target)
+        if self.settings.force_arch is not None:
+            self.arch = get_arch_from_str(self.settings.force_arch)
+        else:
+            self.arch = get_arch(self.target)
+
         if self.settings.register_coloring is True:
             self.regions = self.process.GetMemoryRegions()
         else:

--- a/common/settings.py
+++ b/common/settings.py
@@ -2,6 +2,7 @@
 import configparser
 import os
 
+from arch import supported_arch
 from common.singleton import Singleton
 
 LLEF_CONFIG_PATH = os.path.join(os.path.expanduser('~'), ".llef")
@@ -45,6 +46,11 @@ class LLEFSettings(metaclass=Singleton):
     @property
     def show_trace(self):
         return self._RAW_CONFIG.getboolean(GLOBAL_SECTION, "show_trace", fallback=True)
+
+    @property
+    def force_arch(self):
+        arch = self._RAW_CONFIG.get(GLOBAL_SECTION, "force_arch", fallback=None)
+        return None if arch not in supported_arch else arch
 
     @classmethod
     def _get_setting_names(cls):


### PR DESCRIPTION
The `force_arch` setting allows overriding of the register display architecture.

Note in this implementation none of the other output views are forced to be a different architecture.