### PR TITLE
Detect no color terminal

### DIFF
--- a/commands/settings.py
+++ b/commands/settings.py
@@ -16,7 +16,7 @@ class SettingsCommand(BaseSettingsCommand):
 
     def __init__(self, debugger: SBDebugger, dictionary: Dict[Any, Any]) -> None:
         super().__init__(debugger, dictionary)
-        self.settings = LLEFSettings()
+        self.settings = LLEFSettings(debugger)
 
     @classmethod
     def get_command_parser(cls) -> argparse.ArgumentParser:

--- a/common/context_handler.py
+++ b/common/context_handler.py
@@ -58,7 +58,7 @@ class ContextHandler:
         For up to date documentation on args provided to this function run: `help target stop-hook add`
         """
         self.debugger = debugger
-        self.settings = LLEFSettings()
+        self.settings = LLEFSettings(debugger)
         self.color_settings = LLEFColorSettings()
         self.state = LLEFState()
         change_use_color(self.settings.color_output)

--- a/common/util.py
+++ b/common/util.py
@@ -20,7 +20,7 @@ def change_use_color(new_value: bool) -> None:
 def output_line(line: Any) -> None:
     """
     Format a line of output for printing. Print should not be used elsewhere.
-    Exception - clear_page uses terminal characters intentionally, so does not pass through this
+    Exception - clear_page would not function without terminal characters
     """
     line = str(line)
     ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')


### PR DESCRIPTION
Detect if LLEF is launched in a terminal without color enabled and prevent ansi color characters being displayed.