### PR TITLE
Fix Black formatter workspace defaults

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,5 +50,13 @@
     "python.linting.ignorePatterns": [
         "**/de_bruijn.py",
         "**/site-packages/**/*.py"
+    ],
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "black-formatter.args": [
+        "--line-length=120"
+    ],
+    "flake8.args": [
+        "--max-line-length=120",
+        "--ignore=E203,E701"
     ]
 }


### PR DESCRIPTION
Add Black formatter as the default formatter, deconflict with flake8 and set max line size.