### PR TITLE
[BugFix] display_trace display only last backtrace info

### DIFF
--- a/common/context_handler.py
+++ b/common/context_handler.py
@@ -489,8 +489,9 @@ class ContextHandler:
                 line += get_frame_arguments(
                     current_frame, frame_argument_name_color=TERM_COLORS[self.color_settings.frame_argument_name_color]
                 )
-
-        output_line(line)
+                output_line(line)
+        else:
+            output_line(line)
 
     def load_disassembly_syntax(self, debugger: SBDebugger) -> None:
         """Load the disassembly flavour from LLDB into LLEF's state."""


### PR DESCRIPTION
`Before`

```
[stack]
0x16fdfe2a0│+0000: 0x0000000197522000 ← $sp
0x16fdfe2a8│+0008: 0x000000016fdfe6b8
0x16fdfe2b0│+0010: 0x000000016fdfe6b8
0x16fdfe2b8│+0018: 0x0000000126604ce0
0x16fdfe2c0│+0020: 0x000000016fdfe408
0x16fdfe2c8│+0028: 0x000000016fdfe400
0x16fdfe2d0│+0030: 0x000000016fdfe3f8
0x16fdfe2d8│+0038: 0x0000000000000000
0x16fdfe2e0│+0040: 0x000000016fdfe6b8
0x16fdfe2e8│+0048: 0x0000000200f7c050
0x16fdfe2f0│+0050: 0x0000000200f7c0a0
0x16fdfe2f8│+0058: 0x0000000126604ce0
...
[trace]
[#4]0x197528274(dyld 0x1801cc274)   →  start()
...
Process 30107 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
    frame #0: 0x0000000198b0d004 Foundation`-[NSString(NSPathUtilities) stringByStandardizingPath]
Target 0: (nsbundle_count_3) stopped
```

`After`
```
[stack]
0x16fdfe2a0│+0000: 0x0000000197522000 ← $sp
0x16fdfe2a8│+0008: 0x000000016fdfe6b8
0x16fdfe2b0│+0010: 0x000000016fdfe6b8
0x16fdfe2b8│+0018: 0x0000000126104ce0
0x16fdfe2c0│+0020: 0x000000016fdfe408
0x16fdfe2c8│+0028: 0x000000016fdfe400
0x16fdfe2d0│+0030: 0x000000016fdfe3f8
0x16fdfe2d8│+0038: 0x0000000000000000
0x16fdfe2e0│+0040: 0x000000016fdfe6b8
0x16fdfe2e8│+0048: 0x0000000200f7c050
0x16fdfe2f0│+0050: 0x0000000200f7c0a0
0x16fdfe2f8│+0058: 0x0000000126104ce0
...
[trace]
[#0]0x198b0d004(Foundation 0x1817b1004)   →  -[NSString(NSPathUtilities) stringByStandardizingPath]()
[#1]0x1000011cc(nsbundle_count_3 0x1001011cc)   →  FindDyldImageForExecutablePath()
[#2]0x100000c04(nsbundle_count_3 0x100100c04)   →  PrintBundle()
[#3]0x100000894(nsbundle_count_3 0x100100894)   →  main()
[#4]0x197528274(dyld 0x1801cc274)   →  start()
...
Process 31768 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
    frame #0: 0x0000000198b0d004 Foundation`-[NSString(NSPathUtilities) stringByStandardizingPath]
Target 0: (nsbundle_count_3) stopped.
```

output_line calling is must be in for-loop.
So I add else-case for `go_backtrace` and put output_line function inside for-loop.